### PR TITLE
Feat: Issues data를 받아서 Header title보여주기

### DIFF
--- a/src/components/Common/OrgRefoName/index.tsx
+++ b/src/components/Common/OrgRefoName/index.tsx
@@ -1,0 +1,7 @@
+export const orgRepoName = (issues: any) => {
+  const data =
+    issues?.length !== 0 ? issues[0].url?.split('/').slice(4, 6) : null;
+  const orgName = data !== null ? data[0].toUpperCase() : null;
+  const repoName = data !== null ? data[1].toUpperCase() : null;
+  return { orgName, repoName };
+};

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -2,19 +2,19 @@ import React, { useContext } from 'react';
 import styled from '@emotion/styled';
 import { IconGithub } from '../../assets/index';
 import { useNavigate } from 'react-router-dom';
+import { useIssuesState } from '../../contexts/IssuesContext';
+import { orgRepoName } from '../Common/OrgRefoName';
 
 const Header = () => {
   const navigate = useNavigate();
-  const title = {
-    organization: 'facebook',
-    repository: 'react',
-  };
+  const state = useIssuesState();
+  const { orgName, repoName } = orgRepoName(state.data);
 
   return (
     <HeaderBox>
       <TitleWrap onClick={() => navigate('/')}>
         <IconGithub />
-        {title.organization.toUpperCase()} / {title.repository.toUpperCase()}
+        {orgName} / {repoName}
       </TitleWrap>
     </HeaderBox>
   );


### PR DESCRIPTION
`/common/OrgRepoName.index.tsx` 경로에 메인에서 사용하는 배열데이터를 파라미터로 주입형식으로 분리했습니다. 
```typescript
export const orgRepoName = (issues: any) => {
  const data =
    issues?.length !== 0 ? issues[0].url?.split('/').slice(4, 6) : null;
  const orgName = data !== null ? data[0].toUpperCase() : null;
  const repoName = data !== null ? data[1].toUpperCase() : null;
  return { orgName, repoName };
};
```
### 사용하는 컴포넌트
```typescript
  const { orgName, repoName } = orgRepoName(state.data);
```