### PR TITLE
Feat:  디테일 페이지 api 호출, Context API issue 데이터 추가

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -7,8 +7,9 @@ import { orgRepoName } from '../Common/OrgRefoName';
 
 const Header = () => {
   const navigate = useNavigate();
-  const state = useIssuesState();
-  const { orgName, repoName } = orgRepoName(state.data);
+  //@ts-ignore
+  const { issues, issue } = useIssuesState();
+  const { orgName, repoName } = orgRepoName(issues.data);
 
   return (
     <HeaderBox>

--- a/src/components/IssueDetail/index.tsx
+++ b/src/components/IssueDetail/index.tsx
@@ -11,30 +11,30 @@ const IssueDetail = ({ issue }: any) => {
     <main>
       <Article>
         <LeftContainer>
-          <img src={issue.user.avatar_url} alt="userimage" />
+          <img src={issue?.user.avatar_url} alt="userimage" />
           <div>
             <IconLeaf />
-            {issue.state.toUpperCase()}
+            {issue?.state.toUpperCase()}
           </div>
         </LeftContainer>
 
         <LeftDiv>
           <p className="leftp">
-            <span># {issue.number}</span>
-            {issue.title}
+            <span># {issue?.number}</span>
+            {issue?.title}
           </p>
           <p className="rightp">
-            <span>작성자:{issue.user.login}</span>
-            <span>작성일:{issue.created_at}</span>
+            <span>작성자:{issue?.user.login}</span>
+            <span>작성일:{issue?.created_at}</span>
           </p>
         </LeftDiv>
         <RightDiv>
           <IconMessage />
-          <div> {issue.comments}</div>
+          <div> {issue?.comments}</div>
         </RightDiv>
       </Article>
       <Section>
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{issue.body}</ReactMarkdown>
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{issue?.body}</ReactMarkdown>
       </Section>
     </main>
   );

--- a/src/components/IssueItem/index.tsx
+++ b/src/components/IssueItem/index.tsx
@@ -4,15 +4,12 @@ import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 import { IconMessage } from '../../assets';
 import { IconLeaf } from '../../assets';
-import { useIssuesDispatch } from '../../contexts/IssuesContext';
 
 const IssueItem = ({ issue }: any) => {
   const navigate = useNavigate();
-  const dispatch = useIssuesDispatch();
 
   const handleClick = () => {
-    dispatch({ type: 'GET_ISSUE_DETAIL', payload: issue.id });
-    navigate(`/detail/${issue.id}`);
+    navigate(`/detail/${issue.number}`);
   };
 
   return (

--- a/src/contexts/IssuesContext.tsx
+++ b/src/contexts/IssuesContext.tsx
@@ -45,7 +45,10 @@ const issuesReducer = (state: State, action: Action): State | undefined => {
         (issue: any) => issue.id === action.payload,
       );
       localStorage.setItem('data', JSON.stringify(filteredData[0]));
-      return;
+      return {
+        ...state,
+        data: filteredData,
+      };
 
     default:
       throw new Error(`Unhanded action type`);

--- a/src/contexts/IssuesContext.tsx
+++ b/src/contexts/IssuesContext.tsx
@@ -1,53 +1,82 @@
 import React, { createContext, useReducer, useContext, Dispatch } from 'react';
+import { IssueType } from '../types/issue';
 
 type State = {
   loading: boolean;
-  data: any;
+  data: IssueType | [];
   error: any;
+};
+
+type InitialState = {
+  issues: State;
+  issue: { data: null };
 };
 
 export type Action =
   | { type: 'GET_ISSUES' }
-  | { type: 'GET_ISSUES_SUCCESS'; data: any }
+  | { type: 'GET_ISSUES_SUCCESS'; data: IssueType }
   | { type: 'GET_ISSUES_ERROR'; error: any }
-  | { type: 'GET_ISSUE_DETAIL'; payload: string };
+  | { type: 'GET_ISSUE_DETAIL'; data: IssueType };
 
-const initialState: State = {
-  loading: false,
-  data: [],
+const loadingState = (data: any) => ({
+  loading: true,
+  data,
   error: null,
+});
+
+const success = (data: any) => ({
+  loading: false,
+  data,
+  error: null,
+});
+
+// 실패했을 때의 상태 만들어주는 함수
+const error = (error: any) => ({
+  loading: false,
+  data: null,
+  error: error,
+});
+
+const initialState: InitialState = {
+  issues: {
+    loading: false,
+    data: [],
+    error: null,
+  },
+  issue: {
+    data: null,
+  },
 };
 
-const issuesReducer = (state: State, action: Action): State | undefined => {
+const issuesReducer = (state: InitialState, action: Action): any => {
   switch (action.type) {
     case 'GET_ISSUES':
+      console.log(state);
+
       return {
         ...state,
-        loading: true,
+        issues: loadingState(state.issues.data),
       };
 
     case 'GET_ISSUES_SUCCESS':
       return {
-        loading: false,
-        data: [...state.data, ...action.data],
-        error: null,
+        ...state,
+        //@ts-ignore
+        issues: success([...state.issues.data, ...action.data]),
       };
 
     case 'GET_ISSUES_ERROR':
       return {
-        loading: false,
-        data: null,
-        error: action.error,
+        ...state,
+        issues: error(action.error),
       };
 
     case 'GET_ISSUE_DETAIL':
-      const filteredData = state.data.filter(
-        (issue: any) => issue.id === action.payload,
-      );
-      localStorage.setItem('data', JSON.stringify(filteredData[0]));
+      console.log(action);
+
       return {
         ...state,
-        data: filteredData,
+        issue: success(action.data),
       };
 
     default:

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -1,14 +1,29 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from '@emotion/styled';
 import Header from '../../components/Header';
 import IssueDetail from '../../components/IssueDetail';
+import {
+  useIssuesDispatch,
+  useIssuesState,
+} from '../../contexts/IssuesContext';
+import { getIssue } from '../../service/service';
+import { useParams } from 'react-router';
 
 const Detail = () => {
-  const issue = JSON.parse(localStorage.getItem('data') || '{}');
+  const { id } = useParams();
+  console.log(id);
+  const dispatch = useIssuesDispatch();
+  //@ts-ignore
+  const { issue } = useIssuesState();
+
+  useEffect(() => {
+    getIssue(dispatch, Number(id));
+  }, [id]);
+
   return (
     <Wrap>
       <Header />
-      <IssueDetail issue={issue} />
+      <IssueDetail issue={issue.data} />
     </Wrap>
   );
 };

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -7,7 +7,7 @@ const Detail = () => {
   const issue = JSON.parse(localStorage.getItem('data') || '{}');
   return (
     <Wrap>
-      {/* <Header /> */}
+      <Header />
       <IssueDetail issue={issue} />
     </Wrap>
   );

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -15,7 +15,8 @@ import IssueItem from '../../components/IssueItem';
 
 const Home = () => {
   const dispatch = useIssuesDispatch();
-  const issues = useIssuesState();
+  //@ts-ignore
+  const { issues } = useIssuesState();
   const [page, setPage] = useState(1);
   const pageEnd = useRef<HTMLDivElement>(null);
 
@@ -31,7 +32,6 @@ const Home = () => {
     const observer = new IntersectionObserver(
       entries => {
         if (entries[0].isIntersecting) {
-          console.log('1');
           loadMore();
         }
       },
@@ -47,8 +47,6 @@ const Home = () => {
         observer.unobserve(pageEnd.current);
       }
     };
-    //if (issues.loading) {
-    //}
   }, []);
   return (
     <>

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -53,7 +53,7 @@ const Home = () => {
       <Header />
       <Main>
         {issues.data?.map((issue: any, index: any) => (
-          <React.Fragment key={issue.created_at + issue.number}>
+          <React.Fragment key={issue.created_at + issue.number + index}>
             {index % 4 === 0 && index !== 0 && (
               <Advertisement
                 src={adObject.src}

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -15,3 +15,15 @@ export const getIssues = async (dispatch: Dispatch<Action>, page: number) => {
     dispatch({ type: 'GET_ISSUES_ERROR', error: error });
   }
 };
+
+export const getIssue = async (dispatch: Dispatch<Action>, id: number) => {
+  //dispatch({ type: 'GET_ISSUES' });
+
+  try {
+    const response = await instance.get(`/issues/${id}`);
+
+    dispatch({ type: 'GET_ISSUES_SUCCESS', data: response.data });
+  } catch (error) {
+    dispatch({ type: 'GET_ISSUES_ERROR', error: error });
+  }
+};

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -3,7 +3,7 @@ import instance from './config';
 import { Action } from '../contexts/IssuesContext';
 
 export const getIssues = async (dispatch: Dispatch<Action>, page: number) => {
-  //dispatch({ type: 'GET_ISSUES' });
+  dispatch({ type: 'GET_ISSUES' });
 
   try {
     const response = await instance.get(
@@ -21,8 +21,7 @@ export const getIssue = async (dispatch: Dispatch<Action>, id: number) => {
 
   try {
     const response = await instance.get(`/issues/${id}`);
-
-    dispatch({ type: 'GET_ISSUES_SUCCESS', data: response.data });
+    dispatch({ type: 'GET_ISSUE_DETAIL', data: response.data });
   } catch (error) {
     dispatch({ type: 'GET_ISSUES_ERROR', error: error });
   }

--- a/src/types/issue.ts
+++ b/src/types/issue.ts
@@ -1,0 +1,32 @@
+export interface IssueType {
+  active_lock_reason: null;
+  assignee: null;
+  assignees: [];
+  author_association: string;
+  body: string;
+  closed_at: null;
+  comments: 1;
+  comments_url: string;
+  created_at: string;
+  draft: boolean;
+  events_url: string;
+  html_url: string;
+  id: number;
+  labels: Object;
+  labels_url: string;
+  locked: boolean;
+  milestone: null;
+  node_id: string;
+  number: number;
+  performed_via_github_app: null;
+  pull_request: Object;
+  reactions: Object;
+  repository_url: string;
+  state: string;
+  state_reason: null;
+  timeline_url: string;
+  title: string;
+  updated_at: string;
+  url: string;
+  user: Object;
+}


### PR DESCRIPTION
- 디테일 페이지에 접근했을 때  api 호출(/issues/${id}) 하는식으로 변경
- Context Api 에서 디테일 페이지의 데이터 관리하도록 추가
```tsx
const initialState: InitialState = {
  issues: {
 loading: boolean;
  data: IssueType | [];
  error: any;
  },
  issue: {
   loading: boolean; // 추가할 예정
  data: IssueType | [];
  error: any;
  },
};
```
- 이슈 타입 추가 (type/issue.ts)