### PR TITLE
Style : import문 삭제

### DIFF
--- a/src/styles/Global.tsx
+++ b/src/styles/Global.tsx
@@ -3,7 +3,6 @@ import emotionReset from 'emotion-reset';
 
 const style = css`
   ${emotionReset}
-  @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;300;400;500;700;900&display=swap');
 
   * {
     margin: 0;


### PR DESCRIPTION
Global.tsx 에서 구글폰트(noto sans) import 문 삭제

삭제 사유 : 콘솔창에서 계속 경고문 뜸 ...  
![image](https://github.com/wanted-pre-onboarding-team12/pre-onboarding-11th-3-12/assets/111216062/a8d7bda6-9082-4502-a8c3-6d465ee7b314)

제거 후에도 개발자 도구 및 육안 상으로도 본문은 노토 산스 폰트로 적용되는 것 확인하여 PR 올립니다.

제거 후 화면

<img width="1085" alt="스크린샷 2023-07-14 16 42 44" src="https://github.com/wanted-pre-onboarding-team12/pre-onboarding-11th-3-12/assets/111216062/f852c1dc-cdf5-4f5b-8fea-3b57d868d01d">



다만 CSS 가 원래 제가 디자인했던 부분이 아니다보니 다른 분들 확인하시고 불필요하다 싶으시면 pr 취소로 해도 되지 않을까 싶네요.

